### PR TITLE
Extract shared find_id_by_descriptor utility

### DIFF
--- a/institution_runner.py
+++ b/institution_runner.py
@@ -1,44 +1,11 @@
-import notion_client as nc
-import requests
 import logging
 import time
+
+import notion_client as nc
+import requests
 from tqdm import tqdm
 
-def find_id_by_descriptor(facets, target_descriptor):
-    """
-    Recursively find the ID and facetParameter for a given descriptor across Workday facetParameters.
-
-    Args:
-        facets (list): The facets list loaded from JSON.
-        target_descriptor (str): The descriptor text to search for.
-
-    Returns:
-        tuple: (facetParameter, id) if found, or (None, None) if not found.
-    """
-    target_descriptor = target_descriptor.strip().lower()
-
-    for facet in facets:
-        facet_parameter = facet.get("facetParameter", "")
-        values = facet.get("values", [])
-
-        for value in values:
-            descriptor = value.get("descriptor", "").strip().lower()
-            if descriptor == target_descriptor and "id" in value:
-                return facet_parameter, value["id"]
-
-            if "facetParameter" in value and "values" in value:
-                nested_facet_parameter = value["facetParameter"]
-                nested_values = value["values"]
-
-                found_facet_parameter, found_id = find_id_by_descriptor(
-                    [{"facetParameter": nested_facet_parameter, "values": nested_values}],
-                    target_descriptor
-                )
-
-                if found_id:
-                    return found_facet_parameter, found_id
-
-    return None, None
+from utils import find_id_by_descriptor
 
 def log_with_prefix(level, company_name, message):
     getattr(logging, level)(f"[{company_name}] {message}")

--- a/scraper.py
+++ b/scraper.py
@@ -1,7 +1,9 @@
 import json
 import logging
 from logging.handlers import RotatingFileHandler
+
 from tqdm import tqdm
+
 from config_loader import load_institutions_config
 from institution_runner import run_institution_scraper
 
@@ -34,45 +36,6 @@ HEADERS = {
 }
 
 # --- Function to Find Location IDs ---
-# --- Function to Find ID by Descriptor (General Purpose) ---
-def find_id_by_descriptor(facets, target_descriptor):
-    """
-    Recursively find the ID and facetParameter for a given descriptor across Workday facetParameters.
-
-    Args:
-        facets (list): The facets list loaded from JSON.
-        target_descriptor (str): The descriptor text to search for.
-
-    Returns:
-        tuple: (facetParameter, id) if found, or (None, None) if not found.
-    """
-    target_descriptor = target_descriptor.strip().lower()
-
-    for facet in facets:
-        facet_parameter = facet.get("facetParameter", "")
-        values = facet.get("values", [])
-
-        for value in values:
-            # Check if this value directly matches
-            descriptor = value.get("descriptor", "").strip().lower()
-            if descriptor == target_descriptor and "id" in value:
-                return facet_parameter, value["id"]
-
-            # If value has nested facetParameter + values, recurse
-            if "facetParameter" in value and "values" in value:
-                nested_facet_parameter = value["facetParameter"]
-                nested_values = value["values"]
-
-                found_facet_parameter, found_id = find_id_by_descriptor(
-                    [{"facetParameter": nested_facet_parameter, "values": nested_values}],
-                    target_descriptor
-                )
-
-                if found_id:
-                    return found_facet_parameter, found_id
-
-    return None, None
-
 # --- Main Execution ---
 if __name__ == "__main__":
 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,37 @@
+"""Utility helpers for the Workday scraper project."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def find_id_by_descriptor(
+    facets: Iterable[dict], target_descriptor: str
+) -> tuple[str | None, str | None]:
+    """Recursively find the ID for a descriptor in Workday facets."""
+
+    normalized_descriptor = target_descriptor.strip().lower()
+
+    for facet in facets:
+        facet_parameter = facet.get("facetParameter", "")
+        values = facet.get("values", [])
+
+        for value in values:
+            descriptor = value.get("descriptor", "").strip().lower()
+            if descriptor == normalized_descriptor and "id" in value:
+                return facet_parameter, value["id"]
+
+            if "facetParameter" in value and "values" in value:
+                nested_facet_parameter = value["facetParameter"]
+                nested_values = value["values"]
+
+                found_facet_parameter, found_id = find_id_by_descriptor(
+                    [{"facetParameter": nested_facet_parameter, "values": nested_values}],
+                    target_descriptor,
+                )
+
+                if found_id:
+                    return found_facet_parameter, found_id
+
+    return None, None
+


### PR DESCRIPTION
## Summary
- move the shared `find_id_by_descriptor` helper into a new `utils.py`
- update `institution_runner` to import the shared helper and reuse it
- remove the duplicate function definition from `scraper.py`

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf3f9caab08330850336a5b6459170